### PR TITLE
fix: correct build artifact path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-output
-          path: .cloudflare/
+          path: build/
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-output
-          path: .cloudflare/
+          path: build/
           retention-days: 1
       
       - name: 🚀 Semantic Release


### PR DESCRIPTION
### 🐛 버그 픽스
- 아티팩트 경로 수정: `.cloudflare/` → `build/`
- SvelteKit Cloudflare 어댑터는 `build/` 디렉토리에 빌드 결과물 생성
- Deploy 워크플로우에서 'Artifact not found' 오류 해결

### 📝 오류 원인
Release에서 `.cloudflare/` 경로의 아티팩트를 업로드하려 했으나, 
실제 빌드 결과물은 `build/` 디렉토리에 생성됨

### ✅ 검증
- 로컬에서 `pnpm build` 실행 후 `build/` 디렉토리 확인
- _worker.js, _headers, _redirects 등 Cloudflare Workers 파일 확인

Related to #49