### PR TITLE
fix: 하위 카테고리 없음 메시지에 패딩 추가

### DIFF
--- a/src/lib/components/Posts.svelte
+++ b/src/lib/components/Posts.svelte
@@ -14,18 +14,18 @@
     <section>
         <h2>categories</h2>
 
-        {#if category.childCategories.length}
-            <div class="uppercase flex flex-col gap-2 p-4">
+        <div class="uppercase flex flex-col gap-2 p-4">
+            {#if category.childCategories.length}
                 {#each category.childCategories as childCategory (childCategory.absolutePath)}
                     <a href={localizeHref(childCategory.absolutePath)}>
                         {childCategory.name}
                         <!-- ({childCategory.allPosts.length}) -->
                     </a>
                 {/each}
-            </div>
-        {:else}
-            {m.subCategoryEmpty()}
-        {/if}
+            {:else}
+                {m.subCategoryEmpty()}
+            {/if}
+        </div>
     </section>
 
     <section>


### PR DESCRIPTION
## Summary
- 하위 카테고리가 없을 때 표시되는 메시지에 패딩 추가
- 레이아웃 일관성 개선

## Changes
- `Posts.svelte` 컴포넌트에서 "하위 카테고리가 없습니다." 메시지에 `p-4` 클래스 추가
- 다른 UI 요소들과 동일한 간격 유지

## Test plan
- [x] 하위 카테고리가 없는 카테고리 페이지에서 메시지 확인
- [x] 패딩이 올바르게 적용되었는지 확인
- [x] 다양한 화면 크기에서 레이아웃 확인

## Screenshots
Before: 메시지가 컨테이너에 바짝 붙어있음
After: 적절한 패딩이 적용되어 일관된 간격 유지

Fixes #56

🤖 Generated with [Claude Code](https://claude.ai/code)