### PR TITLE
design: 포스트와 일반 페이지의 헤딩 스타일 분리

### DIFF
--- a/src/lib/components/Post.svelte
+++ b/src/lib/components/Post.svelte
@@ -66,7 +66,7 @@
 			: '';
 </script>
 
-<main>
+<main id="post">
 	<section>
 		{@html postContent.value}
 	</section>

--- a/src/lib/styles/bunny.css
+++ b/src/lib/styles/bunny.css
@@ -215,38 +215,77 @@
 }
 
 @layer base {
-	main {
+	main:not(#post) {
 		h1,
 		h2,
 		h3,
 		h4,
 		h5,
 		h6 {
-			@apply text-white uppercase tracking-wider;
+			@apply text-white bg-primary-500 uppercase tracking-wider;
 		}
 
 		h1 {
-			@apply text-xl font-black p-4 bg-primary-500;
+			@apply text-xl font-black p-4;
 		}
 
 		h2 {
-			@apply text-lg font-extrabold p-3 bg-primary-200-800;
+			@apply text-lg font-extrabold p-3;
 		}
 
 		h3 {
-			@apply text-base font-bold p-3 bg-primary-100-900;
+			@apply text-base font-bold p-3;
 		}
 
 		h4 {
-			@apply text-sm font-semibold p-2 bg-primary-100-900;
+			@apply text-sm font-semibold p-2;
 		}
 
 		h5 {
-			@apply text-sm font-medium p-2 bg-primary-100-900;
+			@apply text-sm font-medium p-2;
 		}
 
 		h6 {
-			@apply text-xs font-normal p-2 bg-primary-100-900;
+			@apply text-xs font-normal p-2;
+		}
+
+		a {
+			@apply hover:preset-tonal-primary;
+		}
+	}
+
+	main#post {
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			@apply text-primary-500 uppercase tracking-wider;
+		}
+
+		h1 {
+			@apply text-xl font-black p-4;
+		}
+
+		h2 {
+			@apply text-lg font-extrabold p-3;
+		}
+
+		h3 {
+			@apply text-base font-bold p-3;
+		}
+
+		h4 {
+			@apply text-sm font-semibold p-2;
+		}
+
+		h5 {
+			@apply text-sm font-medium p-2;
+		}
+
+		h6 {
+			@apply text-xs font-normal p-2;
 		}
 
 		h1:first-child {
@@ -258,7 +297,7 @@
 		}
 
 		a {
-			@apply hover:preset-tonal-primary;
+			@apply hover:preset-tonal-primary underline;
 		}
 
 		ul {


### PR DESCRIPTION
## Summary
- 포스트 페이지와 일반 페이지의 헤딩 스타일을 분리하여 각각 다른 디자인 적용
- 포스트 화면에서는 깔끔한 텍스트 스타일로 가독성 향상

## Changes
### main:not(#post) - 일반 페이지
- 흰색 텍스트 (text-white)
- primary-500 배경색 (bg-primary-500)
- 기존의 강조된 헤더 스타일 유지

### main#post - 포스트 페이지
- primary-500 텍스트 색상 (text-primary-500)
- 배경색 제거로 깔끔한 디자인
- 콘텐츠에 집중할 수 있는 스타일

Closes #58