### PR TITLE
refactor: Convert all padding and margin to vertical-only in main#post

### DIFF
--- a/src/lib/styles/bunny.css
+++ b/src/lib/styles/bunny.css
@@ -255,6 +255,8 @@
 	}
 
 	main#post {
+		@apply p-4;
+
 		h1,
 		h2,
 		h3,
@@ -265,27 +267,27 @@
 		}
 
 		h1 {
-			@apply text-xl font-black p-4;
+			@apply text-xl font-black py-4;
 		}
 
 		h2 {
-			@apply text-lg font-extrabold p-3;
+			@apply text-lg font-extrabold py-3;
 		}
 
 		h3 {
-			@apply text-base font-bold p-3;
+			@apply text-base font-bold py-3;
 		}
 
 		h4 {
-			@apply text-sm font-semibold p-2;
+			@apply text-sm font-semibold py-2;
 		}
 
 		h5 {
-			@apply text-sm font-medium p-2;
+			@apply text-sm font-medium py-2;
 		}
 
 		h6 {
-			@apply text-xs font-normal p-2;
+			@apply text-xs font-normal py-2;
 		}
 
 		h1:first-child {
@@ -293,7 +295,7 @@
 		}
 
 		p {
-			@apply leading-snug m-2;
+			@apply leading-snug my-2;
 		}
 
 		a {
@@ -301,11 +303,11 @@
 		}
 
 		ul {
-			@apply list-disc pl-6 m-2;
+			@apply list-disc pl-6 my-2;
 		}
 
 		pre {
-			@apply m-2 p-2 overflow-y-auto border border-primary-500 rounded;
+			@apply my-2 py-2 px-2 overflow-y-auto border border-primary-500 rounded;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Refactored the main#post styles to use vertical-only padding and margin for better layout consistency.

## Changes
- Changed all  (padding) to  (vertical padding only)
- Changed all  (margin) to  (vertical margin only)
- Pre element now uses  to maintain horizontal padding for code blocks
- Horizontal spacing is now inherited from main#post's 

## Benefits
- More consistent spacing management
- Better separation of concerns between container and content spacing
- Cleaner and more maintainable styles

Closes #64