### PR TITLE
Fix: Correct dark mode utility class from 900 to 950 in table styling

### DIFF
--- a/src/lib/styles/bunny.css
+++ b/src/lib/styles/bunny.css
@@ -314,7 +314,7 @@
 		table {
 			@apply my-4 w-full border-collapse;
 			@apply border border-surface-300-700;
-			@apply bg-surface-50-900;
+			@apply bg-surface-50-950;
 			@apply rounded-lg overflow-x-scroll;
 		}
 


### PR DESCRIPTION
## 요약
- 테이블 스타일링의 잘못된 다크 모드 유틸리티 클래스 수정
- `bg-surface-50-900`을 `bg-surface-50-950`으로 변경하여 Skeleton UI 문법에 맞춤

## 문제/컨텍스트
최근 PR #73에서 잘못된 다크 모드 유틸리티 클래스를 사용하여 빌드 실패가 발생했습니다. 테이블 배경이 `bg-surface-50-900`으로 설정되었으나, Skeleton UI의 올바른 문법은 가장 어두운 색상에 `bg-surface-50-950`을 요구합니다.

## 변경 사항
`src/lib/styles/bunny.css`에서 유틸리티 클래스를 올바른 값으로 업데이트:
- **변경 전**: `bg-surface-50-900`
- **변경 후**: `bg-surface-50-950`

## 기술적 세부사항
- Skeleton UI 디자인 시스템은 색상 단계에 50부터 950까지의 스케일을 사용
- 900 값은 스케일에 존재하지 않아 빌드 실패 발생
- 올바른 가장 어두운 단계는 950

## 관련 이슈
- PR #73의 빌드 실패 수정
- 이슈 #72 (다크 모드에서 테이블 가시성 수정)와 관련

## 테스트 계획
- [x] 올바른 유틸리티 클래스로 빌드 성공
- [x] 다크 모드 테이블 스타일링이 올바르게 렌더링됨
- [x] TypeScript 또는 린팅 오류 없음